### PR TITLE
Remove hardcoded central and compute polling options

### DIFF
--- a/openstack-ceilometer-polling
+++ b/openstack-ceilometer-polling
@@ -1,1 +1,0 @@
-OPTIONS="--polling-namespace 'central' 'compute'"

--- a/openstack-ceilometer-polling.service
+++ b/openstack-ceilometer-polling.service
@@ -5,8 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 User=ceilometer
-EnvironmentFile=/etc/sysconfig/openstack-ceilometer-polling
-ExecStart=/usr/bin/ceilometer-polling --logfile /var/log/ceilometer/polling.log $OPTIONS
+ExecStart=/usr/bin/ceilometer-polling --logfile /var/log/ceilometer/polling.log
 Restart=on-failure
 
 [Install]

--- a/openstack-ceilometer.spec
+++ b/openstack-ceilometer.spec
@@ -17,7 +17,6 @@ Source0:          http://tarballs.openstack.org/%{pypi_name}/%{pypi_name}-%{vers
 Source1:          %{pypi_name}-dist.conf
 Source2:          %{pypi_name}.logrotate
 Source4:          ceilometer-rootwrap-sudoers
-Source5:          openstack-ceilometer-polling
 
 Source10:         %{name}-api.service
 Source11:         %{name}-collector.service
@@ -383,7 +382,6 @@ install -d -m 755 %{buildroot}%{_sysconfdir}/sudoers.d
 install -d -m 755 %{buildroot}%{_sysconfdir}/sysconfig
 install -p -D -m 640 %{SOURCE1} %{buildroot}%{_datadir}/ceilometer/ceilometer-dist.conf
 install -p -D -m 440 %{SOURCE4} %{buildroot}%{_sysconfdir}/sudoers.d/ceilometer
-install -p -D -m 644 %{SOURCE5} %{buildroot}%{_sysconfdir}/sysconfig/openstack-ceilometer-polling
 install -p -D -m 640 etc/ceilometer/ceilometer.conf %{buildroot}%{_sysconfdir}/ceilometer/ceilometer.conf
 install -p -D -m 640 etc/ceilometer/policy.json %{buildroot}%{_sysconfdir}/ceilometer/policy.json
 install -p -D -m 640 etc/ceilometer/pipeline.yaml %{buildroot}%{_sysconfdir}/ceilometer/pipeline.yaml
@@ -591,7 +589,6 @@ exit 0
 
 %files polling
 %{_bindir}/ceilometer-polling
-%attr(-, root, ceilometer) %{_sysconfdir}/sysconfig/openstack-ceilometer-polling
 %{_unitdir}/%{name}-polling.service
 
 


### PR DESCRIPTION
These options should be read from /etc/ceilometer/ceilometer.conf,
not hardcoded in /etc/sysconfig/openstack-ceilometer-polling.
